### PR TITLE
Speed up find_subject_tx_implications and find_subject_dx_implications

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -452,7 +452,7 @@ def get_dna_chg(svtype):
     return {"CODE": dna_chg[0], "DISPLAY": dna_chg[1]}
 
 
-def create_fhir_variant_resource(record, subject):
+def create_fhir_variant_resource(record, ref_seq, subject):
     vid = f"dv-{str(record['_id'])}"
 
     resource = OrderedDict()
@@ -497,7 +497,7 @@ def create_fhir_variant_resource(record, subject):
                                                        "code": "48013-7",
                                                        "display": "Genomic reference sequence ID"}]},
                                   "valueCodeableConcept": {"coding": [{"system": "http://www.ncbi.nlm.nih.gov/nuccore",
-                                                                       "code": f"{get_ref_seq_by_chrom_and_build(record['genomicBuild'], record['CHROM'])}"}]}})
+                                                                       "code": ref_seq}]}})
 
     # Allelic State
     if "allelicState" in record and (('SVTYPE' not in record) or ('SVTYPE' in record and 'genomicSourceClass' in record and record['SVTYPE'] in ['DUP', 'DEL', 'INV', 'INS'] and record['genomicSourceClass'].lower() == 'germline')):

--- a/app/endpoints.py
+++ b/app/endpoints.py
@@ -128,7 +128,8 @@ def find_subject_variants(
                 variant_fhir_profiles = []
 
                 for record in variant_q:
-                    resource = create_fhir_variant_resource(record, subject)
+                    ref_seq = get_ref_seq_by_chrom_and_build(record['genomicBuild'], record['CHROM'])
+                    resource = create_fhir_variant_resource(record, ref_seq, subject)
 
                     variant_fhir_profiles.append(resource)
 
@@ -259,7 +260,8 @@ def find_subject_specific_variants(
             variant_fhir_profiles = []
 
             for record in variant_q:
-                resource = create_fhir_variant_resource(record, subject)
+                ref_seq = get_ref_seq_by_chrom_and_build(record['genomicBuild'], record['CHROM'])
+                resource = create_fhir_variant_resource(record, ref_seq, subject)
 
                 variant_fhir_profiles.append(resource)
 
@@ -405,7 +407,8 @@ def find_subject_structural_intersecting_variants(
                 variant_fhir_profiles = []
 
                 for record in variant_q:
-                    resource = create_fhir_variant_resource(record, subject)
+                    ref_seq = get_ref_seq_by_chrom_and_build(record['genomicBuild'], record['CHROM'])
+                    resource = create_fhir_variant_resource(record, ref_seq, subject)
 
                     variant_fhir_profiles.append(resource)
 
@@ -534,7 +537,8 @@ def find_subject_structural_subsuming_variants(
                 variant_fhir_profiles = []
 
                 for record in variant_q:
-                    resource = create_fhir_variant_resource(record, subject)
+                    ref_seq = get_ref_seq_by_chrom_and_build(record['genomicBuild'], record['CHROM'])
+                    resource = create_fhir_variant_resource(record, ref_seq, subject)
 
                     variant_fhir_profiles.append(resource)
 
@@ -853,6 +857,8 @@ def find_subject_tx_implications(
         query_results = query_CIVIC_by_variants(normalized_variants, condition_code_list, treatment_code_list, query)
 
         for res in query_results:
+            if res["txImplicationMatches"]:
+                ref_seq = get_ref_seq_by_chrom_and_build(res['genomicBuild'], res['CHROM'])
             for implication in res["txImplicationMatches"]:
                 parameter = OrderedDict()
                 parameter["name"] = "implications"
@@ -863,7 +869,7 @@ def find_subject_tx_implications(
                 "name": "implication",
                 "resource": implication_profile
                 })
-                resource = create_fhir_variant_resource(res, subject)
+                resource = create_fhir_variant_resource(res, ref_seq, subject)
 
                 add_variation_id(resource, implication["variationID"])
 
@@ -978,8 +984,8 @@ def find_subject_tx_implications(
 
             variant_fhir_profiles = []
             for varItem in res["patientMatches"]:
-                
-                resource = create_fhir_variant_resource(varItem, subject)
+                ref_seq = get_ref_seq_by_chrom_and_build(varItem['genomicBuild'], varItem['CHROM'])
+                resource = create_fhir_variant_resource(varItem, ref_seq, subject)
 
                 add_variation_id(resource, res["variationID"])
 
@@ -1018,7 +1024,8 @@ def find_subject_tx_implications(
 
             variant_fhir_profiles = []
             for varItem in res["patientMatches"]:
-                resource = create_fhir_variant_resource(varItem, subject)
+                ref_seq = get_ref_seq_by_chrom_and_build(varItem['genomicBuild'], varItem['CHROM'])
+                resource = create_fhir_variant_resource(varItem, ref_seq, subject)
 
                 add_variation_id(resource, res["variationID"])
 
@@ -1120,6 +1127,8 @@ def find_subject_dx_implications(
         query_results = query_clinvar_by_variants(normalized_variants, condition_code_list, query)
 
         for res in query_results:
+            if res["dxImplicationMatches"]:
+                ref_seq = get_ref_seq_by_chrom_and_build(res['genomicBuild'], res['CHROM'])
             for implication in res["dxImplicationMatches"]:
                 parameter = OrderedDict()
                 parameter["name"] = "implications"
@@ -1131,7 +1140,7 @@ def find_subject_dx_implications(
                 "name": "implication",
                 "resource": implication_profile
                 })
-                resource = create_fhir_variant_resource(res, subject)
+                resource = create_fhir_variant_resource(res, ref_seq, subject)
 
                 add_variation_id(resource, implication["variationID"])
 
@@ -1164,7 +1173,8 @@ def find_subject_dx_implications(
             })
 
             for varItem in res["patientMatches"]:
-                resource = create_fhir_variant_resource(varItem, subject)
+                ref_seq = get_ref_seq_by_chrom_and_build(varItem['genomicBuild'], varItem['CHROM'])
+                resource = create_fhir_variant_resource(varItem, ref_seq, subject)
 
                 add_variation_id(resource, res["variationID"])
 

--- a/tests/integration_tests/test_subject_phenotype_operations.py
+++ b/tests/integration_tests/test_subject_phenotype_operations.py
@@ -87,3 +87,12 @@ def test_find_subject_dx_implications_4(client):
     response = client.get(url)
 
     compare_actual_and_expected_output(f'{FIND_SUBJECT_DX_IMPLICATIONS_OUTPUT_DIR}4.json', response.json)
+
+def test_find_subject_dx_implications_5(client):
+    """
+    Query with multiple ranges which have different chromosomes
+    """
+    url = find_subject_dx_implications_query('subject=HG00403&ranges=NC_000001.11:237042183-237833988,NC_000005.9:112043194-112181936,NC_000019.9:11200138-11244496,NC_000013.10:32889644-32974405,NC_000014.9:23412739-23435677')
+    response = client.get(url)
+
+    compare_actual_and_expected_output(f'{FIND_SUBJECT_DX_IMPLICATIONS_OUTPUT_DIR}5.json', response.json)


### PR DESCRIPTION
## Description

- Don't attempt to normalise variants in `find_subject_tx_implications` and `find_subject_dx_implications` when the ranges parameter is populated.
- Avoid calling `get_ref_seq_by_chrom_and_build` for each implication of each result in `find_subject_tx_implications` and `find_subject_dx_implications`.
- Cache pyliftover objects to speed up `get_lift_over_range` for `find_subject_tx_implications` and `find_subject_dx_implications` when `ranges` are provided.
- Add a test for `find-subject-dx-implications` to cover queries which have multiple `ranges` where each range has a different chromosome.

Fixes # (issue)

TBD

## How Has This Been Tested?

Currently, `find-subject-dx-implications` takes about 1.74 min on my laptop for [this query](https://fhir-gen-ops.herokuapp.com/subject-operations/phenotype-operations/$find-subject-dx-implications?subject=HG00403&ranges=NC_000017.11:43044294-43125364). With these changes, the runtime was reduced to 13.27 s.

- [x] Integration Tests
- [x] Unit Tests
