### PR TITLE
Fix build37 get_variants for range queries

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -360,6 +360,7 @@ def get_variants(ranges, query):
             if "SPDI" in variant:
                 variants.append({'BUILD': chrom["PGB"]["BUILD"], 'SPDI': variant["SPDI"]})
 
+    del query["genomicBuild"]
     del query["$and"]
 
     return variants


### PR DESCRIPTION
Unfortunately, `get_variants` currently mutates the input `query` parameter and sets in it the `genomicBuild` without unsetting it.

Since we no longer normalise variants to have them both in build37 and build38, then the final query will end up looking for build38 while all the provided variants are in build37.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration Tests
- [ ] Unit Tests
