### PR TITLE
Adding features based on genomicSourClass

### DIFF
--- a/app/endpoints.py
+++ b/app/endpoints.py
@@ -595,9 +595,9 @@ def find_subject_haplotypes(
         query["specimenID"] = {"$in": specimenIdentifiers}
 
     # Genomic Source Class Query
-    # if genomicSourceClass:
-    #     genomicSourceClass = genomicSourceClass.strip().lower()
-    #     query["genomicSourceClass"] = {"$eq": genomicSourceClass}
+    if genomicSourceClass:
+        genomicSourceClass = genomicSourceClass.strip().lower()
+        query["genomicSourceClass"] = {"$eq": genomicSourceClass}
 
     # Result Object
     result = OrderedDict()
@@ -653,6 +653,13 @@ def find_subject_haplotypes(
                 "resource": genotype_profile
             })
 
+        result["parameter"].append(parameter)
+
+    # Add genomic source class option to result object
+    if genomicSourceClass:
+        parameter = OrderedDict()
+        parameter["name"] = "genomicSourceClass"
+        parameter["part"] = [{"name": genomicSourceClass.capitalize(), "valueString": genomicSourceClass}]
         result["parameter"].append(parameter)
 
     if not result["parameter"]:

--- a/tests/expected_outputs/find_subject_haplotypes/5.json
+++ b/tests/expected_outputs/find_subject_haplotypes/5.json
@@ -1,0 +1,23 @@
+{
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "haplotypes",
+            "part": [
+                {
+                    "name": "geneItem",
+                    "valueString": "HGNC:2625"
+                }
+            ]
+        },
+        {
+            "name": "genomicSourceClass",
+            "part": [
+                {
+                    "name": "Germline",
+                    "valueString": "germline"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/expected_outputs/find_subject_haplotypes/6.json
+++ b/tests/expected_outputs/find_subject_haplotypes/6.json
@@ -1,0 +1,23 @@
+{
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "haplotypes",
+            "part": [
+                {
+                    "name": "geneItem",
+                    "valueString": "HGNC:2625"
+                }
+            ]
+        },
+        {
+            "name": "genomicSourceClass",
+            "part": [
+                {
+                    "name": "Somatic",
+                    "valueString": "somatic"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/integration_tests/test_subject_genotype_operations.py
+++ b/tests/integration_tests/test_subject_genotype_operations.py
@@ -249,6 +249,20 @@ def test_find_subject_haplotypes_4(client):
     tu.compare_actual_and_expected_output(f'{tu.FIND_SUBJECT_HAPLOTYPES_OUTPUT_DIR}4.json', response.json)
 
 
+def test_find_subject_haplotypes_5(client):
+    url = tu.find_subject_haplotypes_query('subject=NB6TK328&genes=http://www.genenames.org/geneId|HGNC:2625&genomicSourceClass=germline')
+    response = client.get(url)
+
+    tu.compare_actual_and_expected_output(f'{tu.FIND_SUBJECT_HAPLOTYPES_OUTPUT_DIR}5.json', response.json)
+
+
+def test_find_subject_haplotypes_6(client):
+    url = tu.find_subject_haplotypes_query('subject=NB6TK328&genes=http://www.genenames.org/geneId|HGNC:2625&genomicSourceClass=somatic')
+    response = client.get(url)
+
+    tu.compare_actual_and_expected_output(f'{tu.FIND_SUBJECT_HAPLOTYPES_OUTPUT_DIR}6.json', response.json)
+
+
 """
 Find Subject Specific Haplotypes Tests
 --------------------------------------


### PR DESCRIPTION
## Description

Added the feature for searching the database based on either germline or somatic genomicSourceClass 

Fixes #48

This feature is only added for the find_subject_haplotypes with single genes and after the review i can add this feature to other genomic operations 

## How Has This Been Tested?

It has been tested using the pytest command

* [x]  Integration Tests
* [x]  Unit Tests

