### PR TITLE
Allow CORS for all domains on all routes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 import connexion
 import flask
+from flask_cors import CORS
 import os
 
 
@@ -24,6 +25,13 @@ def create_app():
 
     app = connex_app.app
     app.register_blueprint(bp)
+
+    # Allow CORS for all domains on all routes
+    CORS(app, resources={
+        r"/subject-operations/.*": {"origins": "*"},
+        r"/population-operations/.*": {"origins": "*"},
+        r"/utilities/.*": {"origins": "*"}
+    })
 
     # Avoid sorting the output JSON
     app.config['JSON_SORT_KEYS'] = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 connexion[swagger-ui]==2.14.0
 dnspython==2.2.1
 Flask==2.2.2
+flask_cors==4.0.0
 gunicorn==20.1.0
 pandas==1.3.5
 pyfastx==0.9.1


### PR DESCRIPTION
## Description

This change allows browsers to fetch data from this API when the request comes in from 3rd party domains.

Fixes # (issue) N/A (email from Justin)

## How Has This Been Tested?

This is based on the example from [here](https://flask-cors.readthedocs.io/en/latest/#resource-specific-cors). I tested it locally by running the app in the debugger in VS Code and a custom domain in `/etc/hosts` (`127.0.0.1 test.local`) and `python3 -m http.server` running in a separate terminal serving a simple static html on `http://localhost:8000/test.html`

```html
<!DOCTYPE html>
<html>

<head>
    <meta charset="utf-8" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
    <meta name="viewport" content="width=device-width" />
    <title>Fetch Local JSON</title>
</head>
<script>
    fetch('http://test.local:5000/subject-operations/phenotype-operations/$find-subject-tx-implications?subject=CA12345&treatments=http://www.nlm.nih.gov/research/umls/rxnorm|1147220', {
        method: 'GET',
        headers: {
            'Accept': 'application/json',
        },
    })
        .then(response => response.json())
        .then(response => console.log(JSON.stringify(response)))
</script>

</html>
```

When you open the page (`http://localhost:8000/test.html`) in the browser, go to the web console and check out the Networking tab. Without the code changes, API requests to `http://test.local:5000` are blocked.

- [x] Integration Tests
- [x] Unit Tests
