### PR TITLE
Fix find-subject-tx-implications bug

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -716,10 +716,11 @@ def create_tx_implication_profile_civic(implication, subject, vids):
                                                                            "code": f"{ptc['code']}",
                                                                            "display": f"{ptc['display']}"}]}})
 
-    resource["component"].append({"code": {"coding": [{"system": "http://loinc.org",
-                                                       "code": "93044-6",
-                                                       "display": "Level of evidence"}]},
-                                  "valueCodeableConcept": {"text": f"{implication['evidenceLevel']}"}})
+    if 'evidenceLevel' in implication:
+        resource["component"].append({"code": {"coding": [{"system": "http://loinc.org",
+                                                           "code": "93044-6",
+                                                           "display": "Level of evidence"}]},
+                                      "valueCodeableConcept": {"text": f"{implication['evidenceLevel']}"}})
 
     for med in implication['medicationAssessed']:
         resource["component"].append({"code": {"coding": [{"system": "http://loinc.org",

--- a/tests/expected_outputs/find_population_dx_implications/1.json
+++ b/tests/expected_outputs/find_population_dx_implications/1.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_dx_implications/2.json
+++ b/tests/expected_outputs/find_population_dx_implications/2.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 }
             ]

--- a/tests/expected_outputs/find_population_dx_implications/3.json
+++ b/tests/expected_outputs/find_population_dx_implications/3.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_dx_implications/4.json
+++ b/tests/expected_outputs/find_population_dx_implications/4.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_haplotypes/1.json
+++ b/tests/expected_outputs/find_population_specific_haplotypes/1.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_haplotypes/2.json
+++ b/tests/expected_outputs/find_population_specific_haplotypes/2.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_haplotypes/3.json
+++ b/tests/expected_outputs/find_population_specific_haplotypes/3.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_haplotypes/4.json
+++ b/tests/expected_outputs/find_population_specific_haplotypes/4.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {
@@ -42,7 +42,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {
@@ -67,7 +67,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_variants/1.json
+++ b/tests/expected_outputs/find_population_specific_variants/1.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 }
             ]

--- a/tests/expected_outputs/find_population_specific_variants/2.json
+++ b/tests/expected_outputs/find_population_specific_variants/2.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_structural_intersecting_variants/1.json
+++ b/tests/expected_outputs/find_population_structural_intersecting_variants/1.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_structural_intersecting_variants/2.json
+++ b/tests/expected_outputs/find_population_structural_intersecting_variants/2.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 }
             ]
@@ -38,7 +38,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_structural_intersecting_variants/3.json
+++ b/tests/expected_outputs/find_population_structural_intersecting_variants/3.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_structural_subsuming_variants/1.json
+++ b/tests/expected_outputs/find_population_structural_subsuming_variants/1.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 }
             ]

--- a/tests/expected_outputs/find_population_structural_subsuming_variants/2.json
+++ b/tests/expected_outputs/find_population_structural_subsuming_variants/2.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 }
             ]
@@ -38,7 +38,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_tx_implications/2.json
+++ b/tests/expected_outputs/find_population_tx_implications/2.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_tx_implications/3.json
+++ b/tests/expected_outputs/find_population_tx_implications/3.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_tx_implications/4.json
+++ b/tests/expected_outputs/find_population_tx_implications/4.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_tx_implications/5.json
+++ b/tests/expected_outputs/find_population_tx_implications/5.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1112
+                        "value": 1114
                     }
                 },
                 {

--- a/tests/expected_outputs/find_subject_tx_implications/7.json
+++ b/tests/expected_outputs/find_subject_tx_implications/7.json
@@ -1,0 +1,543 @@
+{
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "implications",
+            "part": [
+                {
+                    "name": "implication",
+                    "resource": {
+                        "resourceType": "Observation",
+                        "id": "dv-6508e7e22171de9b6d744453",
+                        "meta": {
+                            "profile": [
+                                "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/therapeutic-implication"
+                            ]
+                        },
+                        "status": "final",
+                        "category": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                                        "code": "laboratory"
+                                    }
+                                ]
+                            }
+                        ],
+                        "code": {
+                            "coding": [
+                                {
+                                    "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes-cs",
+                                    "code": "therapeutic-implication"
+                                }
+                            ]
+                        },
+                        "subject": {
+                            "reference": "Patient/TCGA-DD-A1EH"
+                        },
+                        "derivedFrom": [
+                            {
+                                "reference": "Observation/dv-88caba1c34f74b6bbc482df53025a69a"
+                            }
+                        ],
+                        "component": [
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "81259-4",
+                                            "display": "phenotypic treatment context"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://disease-ontology.org",
+                                            "code": "684",
+                                            "display": "Hepatocellular carcinoma"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "51963-7",
+                                            "display": "medication-assessed"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://clinicaltrials.gov/",
+                                            "code": "NCT05023655",
+                                            "display": "NCT05023655"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes-cs",
+                                            "code": "predicted-therapeutic-implication",
+                                            "display": "predicted-therapeutic-implication"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "text": "Patient eligible for clinical trial"
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "variant",
+                    "resource": {
+                        "resourceType": "Observation",
+                        "id": "dv-88caba1c34f74b6bbc482df53025a69a",
+                        "meta": {
+                            "profile": [
+                                "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                            ]
+                        },
+                        "status": "final",
+                        "category": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                                        "code": "laboratory"
+                                    }
+                                ]
+                            }
+                        ],
+                        "code": {
+                            "coding": [
+                                {
+                                    "system": "http://loinc.org",
+                                    "code": "69548-6",
+                                    "display": "Genetic variant assessment"
+                                }
+                            ]
+                        },
+                        "subject": {
+                            "reference": "Patient/TCGA-DD-A1EH"
+                        },
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "http://loinc.org",
+                                    "code": "LA9633-4",
+                                    "display": "present"
+                                }
+                            ]
+                        },
+                        "component": [
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "48002-0",
+                                            "display": "Genomic Source Class"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "LA6684-0",
+                                            "display": "somatic"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "48013-7",
+                                            "display": "Genomic reference sequence ID"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                            "code": "NC_000001.10"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "81252-9",
+                                            "display": "Discrete genetic variant"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://api.ncbi.nlm.nih.gov/variation/v0/",
+                                            "code": "NC_000001.10:27105549:C:T",
+                                            "display": "NC_000001.10:27105549:C:T"
+                                        },
+                                        {
+                                            "system": "https://clinicaltrials.gov/",
+                                            "code": "NCT05023655"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "69547-8",
+                                            "display": "Genomic Ref allele [ID]"
+                                        }
+                                    ]
+                                },
+                                "valueString": "C"
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "69551-0",
+                                            "display": "Genomic Alt allele [ID]"
+                                        }
+                                    ]
+                                },
+                                "valueString": "T"
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "92822-6",
+                                            "display": "Genomic coord system"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "LA30100-4",
+                                            "display": "0-based interval counting"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "81254-5",
+                                            "display": "Variant exact start-end"
+                                        }
+                                    ]
+                                },
+                                "valueRange": {
+                                    "low": {
+                                        "value": 27105549
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "name": "implications",
+            "part": [
+                {
+                    "name": "implication",
+                    "resource": {
+                        "resourceType": "Observation",
+                        "id": "dv-6508ea502171de9b6d744454",
+                        "meta": {
+                            "profile": [
+                                "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/therapeutic-implication"
+                            ]
+                        },
+                        "status": "final",
+                        "category": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                                        "code": "laboratory"
+                                    }
+                                ]
+                            }
+                        ],
+                        "code": {
+                            "coding": [
+                                {
+                                    "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes-cs",
+                                    "code": "therapeutic-implication"
+                                }
+                            ]
+                        },
+                        "subject": {
+                            "reference": "Patient/TCGA-DD-A1EH"
+                        },
+                        "derivedFrom": [
+                            {
+                                "reference": "Observation/dv-dd9754abe5954342896ff349289ca20d"
+                            }
+                        ],
+                        "component": [
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "81259-4",
+                                            "display": "phenotypic treatment context"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://disease-ontology.org",
+                                            "code": "684",
+                                            "display": "Hepatocellular carcinoma"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "51963-7",
+                                            "display": "medication-assessed"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://clinicaltrials.gov/",
+                                            "code": "NCT05023655",
+                                            "display": "NCT05023655"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://hl7.org/fhir/uv/genomics-reporting/CodeSystem/tbd-codes-cs",
+                                            "code": "predicted-therapeutic-implication",
+                                            "display": "predicted-therapeutic-implication"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "text": "Patient eligible for clinical trial"
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "variant",
+                    "resource": {
+                        "resourceType": "Observation",
+                        "id": "dv-dd9754abe5954342896ff349289ca20d",
+                        "meta": {
+                            "profile": [
+                                "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+                            ]
+                        },
+                        "status": "final",
+                        "category": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                                        "code": "laboratory"
+                                    }
+                                ]
+                            }
+                        ],
+                        "code": {
+                            "coding": [
+                                {
+                                    "system": "http://loinc.org",
+                                    "code": "69548-6",
+                                    "display": "Genetic variant assessment"
+                                }
+                            ]
+                        },
+                        "subject": {
+                            "reference": "Patient/TCGA-DD-A1EH"
+                        },
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "http://loinc.org",
+                                    "code": "LA9633-4",
+                                    "display": "present"
+                                }
+                            ]
+                        },
+                        "component": [
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "48002-0",
+                                            "display": "Genomic Source Class"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "LA6684-0",
+                                            "display": "somatic"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "48013-7",
+                                            "display": "Genomic reference sequence ID"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                                            "code": "NC_000001.10"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "81252-9",
+                                            "display": "Discrete genetic variant"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://api.ncbi.nlm.nih.gov/variation/v0/",
+                                            "code": "NC_000001.10:27106893::T",
+                                            "display": "NC_000001.10:27106893::T"
+                                        },
+                                        {
+                                            "system": "https://clinicaltrials.gov/",
+                                            "code": "NCT05023655"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "69547-8",
+                                            "display": "Genomic Ref allele [ID]"
+                                        }
+                                    ]
+                                },
+                                "valueString": "G"
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "69551-0",
+                                            "display": "Genomic Alt allele [ID]"
+                                        }
+                                    ]
+                                },
+                                "valueString": "GT"
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "92822-6",
+                                            "display": "Genomic coord system"
+                                        }
+                                    ]
+                                },
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "LA30100-4",
+                                            "display": "0-based interval counting"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "code": {
+                                    "coding": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "81254-5",
+                                            "display": "Variant exact start-end"
+                                        }
+                                    ]
+                                },
+                                "valueRange": {
+                                    "low": {
+                                        "value": 27106892
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/integration_tests/test_subject_phenotype_operations.py
+++ b/tests/integration_tests/test_subject_phenotype_operations.py
@@ -57,6 +57,13 @@ def test_find_subject_tx_implications_6(client):
     tu.compare_actual_and_expected_output(f'{tu.FIND_SUBJECT_TX_IMPLICATIONS_OUTPUT_DIR}6.json', response.json)
 
 
+def test_find_subject_tx_implications_7(client):
+    url = tu.find_subject_tx_implications_query('subject=TCGA-DD-A1EH&ranges=NC_000001.11:20000000-40000000')
+    response = client.get(url)
+
+    tu.compare_actual_and_expected_output(f'{tu.FIND_SUBJECT_TX_IMPLICATIONS_OUTPUT_DIR}7.json', response.json)
+
+
 """
 Find Subject Dx Implications Tests
 ----------------------------------


### PR DESCRIPTION
## Description

Don't panic when the returned results for find-subject-tx-implications don't contain `evidenceLevel`.

Also update the integration tests since more patients have been added.

## How Has This Been Tested?

Test query: https://fhir-gen-ops.herokuapp.com/subject-operations/phenotype-operations/$find-subject-tx-implications?subject=TCGA-DD-A1EH&ranges=NC_000001.11:20000000-40000000

I added an integration test to cover this scenario.

- [x] Integration Tests
- [ ] Unit Tests
