### PR TITLE
removal of Parameter[parts] in find_subject_tx_implications and find_subject_dx_implications 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     "editor.bracketPairColorization.enabled": true,
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
-    "python.formatting.provider": "autopep8",
+    "python.formatting.provider": "none",
     "python.formatting.autopep8Args": [
         "--max-line-length=200"
     ],
@@ -20,5 +20,8 @@
         "."
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    }
 }

--- a/app/endpoints.py
+++ b/app/endpoints.py
@@ -1003,7 +1003,7 @@ def find_subject_tx_implications(
                 implication_profile = common.create_tx_implication_profile_civic(
                     implication, subject, [str(res["_id"])]
                 )
-                impl_parameter["resource"] = {
+                impl_parameter = {
                     "name": "implication",
                     "resource": implication_profile,
                 }
@@ -1014,16 +1014,16 @@ def find_subject_tx_implications(
                 common.add_variation_id(resource, implication["variationID"])
 
                 var_parameter = OrderedDict()
-                var_parameter["resource"] = {"name": "variant", "resource": resource}
+                var_parameter = {"name": "variant", "resource": resource}
 
                 result["parameter"].append(var_parameter)
 
         if not result["parameter"]:
             result.pop("parameter")
-        else:
-            result["parameter"] = sorted(
-                result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
-            )
+        # else:
+        #   result["parameter"] = sorted(
+        #       result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
+        #    )
 
         return jsonify(result)
 
@@ -1042,7 +1042,7 @@ def find_subject_tx_implications(
                 implication_profile = common.create_tx_implication_profile_pharmgkb(
                     implication, subject, [str(res["_id"])]
                 )
-                impl_parameter["resource"] = {
+                impl_parameter = {
                     "name": "implication",
                     "resource": implication_profile,
                 }
@@ -1063,20 +1063,19 @@ def find_subject_tx_implications(
 
                 common.add_variation_id(genotype_profile, implication["variationID"])
 
-                var_parameter["resource"] = {
+                var_parameter = {
                     "name": "genotype",
                     "resource": genotype_profile,
                 }
-                print(var_parameter)
 
                 result["parameter"].append(var_parameter)
 
         if not result["parameter"]:
             result.pop("parameter")
-        else:
-            result["parameter"] = sorted(
-                result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
-            )
+        # else:
+        #    result["parameter"] = sorted(
+        #        result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
+        #    )
 
         return jsonify(result)
 
@@ -1094,7 +1093,7 @@ def find_subject_tx_implications(
             implication_profile = common.create_tx_implication_profile_pharmgkb(
                 res, subject, [str(i["_id"]) for i in res["patientMatches"]]
             )
-            impl_parameter["resource"] = {
+            impl_parameter = {
                 "name": "implication",
                 "resource": implication_profile,
             }
@@ -1134,7 +1133,7 @@ def find_subject_tx_implications(
             implication_profile = common.create_tx_implication_profile_civic(
                 res, subject, [str(i["_id"]) for i in res["patientMatches"]]
             )
-            impl_parameter["resource"] = {
+            impl_parameter = {
                 "name": "implication",
                 "resource": implication_profile,
             }
@@ -1160,16 +1159,16 @@ def find_subject_tx_implications(
 
             for resource in variant_fhir_profiles:
                 var_parameter = OrderedDict()
-                var_parameter["resource"] = {"name": "variant", "resource": resource}
+                var_parameter = {"name": "variant", "resource": resource}
 
             result["parameter"].append(var_parameter)
 
         if not result["parameter"]:
             result.pop("parameter")
-        else:
-            result["parameter"] = sorted(
-                result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
-            )
+        # else:
+        #    result["parameter"] = sorted(
+        #        result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
+        #    )
 
         return jsonify(result)
 
@@ -1183,7 +1182,7 @@ def find_subject_tx_implications(
             implication_profile = common.create_tx_implication_profile_civic(
                 res, subject, [str(i["_id"]) for i in res["patientMatches"]]
             )
-            impl_parameter["resource"] = {
+            impl_parameter = {
                 "name": "implication",
                 "resource": implication_profile,
             }
@@ -1210,16 +1209,16 @@ def find_subject_tx_implications(
 
             for resource in variant_fhir_profiles:
                 var_parameter = OrderedDict()
-                var_parameter["resource"] = {"name": "variant", "resource": resource}
+                var_parameter = {"name": "variant", "resource": resource}
 
             result["parameter"].append(var_parameter)
 
         if not result["parameter"]:
             result.pop("parameter")
-        else:
-            result["parameter"] = sorted(
-                result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
-            )
+        # else:
+        #    result["parameter"] = sorted(
+        #        result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
+        #    )
 
         return jsonify(result)
 
@@ -1350,10 +1349,10 @@ def find_subject_dx_implications(
 
         if not result["parameter"]:
             result.pop("parameter")
-        else:
-            result["parameter"] = sorted(
-                result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
-            )
+        # else:
+        #    result["parameter"] = sorted(
+        #        result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
+        #    )
 
         return jsonify(result)
 
@@ -1381,18 +1380,16 @@ def find_subject_dx_implications(
 
                 common.add_variation_id(resource, res["variationID"])
                 var_parameter = OrderedDict()
-                var_parameter["resource"] = {"name": "variant",
-                                             "resource": resource}
+                var_parameter["resource"] = {"name": "variant", "resource": resource}
 
                 result["parameter"].append(var_parameter)
 
-
         if not result["parameter"]:
             result.pop("parameter")
-        else:
-            result["parameter"] = sorted(
-                result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
-            )
+        # else:
+        #    result["parameter"] = sorted(
+        #        result["parameter"], key=lambda d: d["part"][0]["resource"]["id"]
+        #    )
 
         return jsonify(result)
 

--- a/tests/expected_outputs/find_population_dx_implications/1.json
+++ b/tests/expected_outputs/find_population_dx_implications/1.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_dx_implications/2.json
+++ b/tests/expected_outputs/find_population_dx_implications/2.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 }
             ]

--- a/tests/expected_outputs/find_population_dx_implications/3.json
+++ b/tests/expected_outputs/find_population_dx_implications/3.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_dx_implications/4.json
+++ b/tests/expected_outputs/find_population_dx_implications/4.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_haplotypes/1.json
+++ b/tests/expected_outputs/find_population_specific_haplotypes/1.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_haplotypes/2.json
+++ b/tests/expected_outputs/find_population_specific_haplotypes/2.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_haplotypes/3.json
+++ b/tests/expected_outputs/find_population_specific_haplotypes/3.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_haplotypes/4.json
+++ b/tests/expected_outputs/find_population_specific_haplotypes/4.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {
@@ -42,7 +42,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {
@@ -67,7 +67,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_specific_variants/1.json
+++ b/tests/expected_outputs/find_population_specific_variants/1.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 }
             ]

--- a/tests/expected_outputs/find_population_specific_variants/2.json
+++ b/tests/expected_outputs/find_population_specific_variants/2.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_structural_intersecting_variants/1.json
+++ b/tests/expected_outputs/find_population_structural_intersecting_variants/1.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_structural_intersecting_variants/2.json
+++ b/tests/expected_outputs/find_population_structural_intersecting_variants/2.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 }
             ]
@@ -38,7 +38,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_structural_intersecting_variants/3.json
+++ b/tests/expected_outputs/find_population_structural_intersecting_variants/3.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_structural_subsuming_variants/1.json
+++ b/tests/expected_outputs/find_population_structural_subsuming_variants/1.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 }
             ]

--- a/tests/expected_outputs/find_population_structural_subsuming_variants/2.json
+++ b/tests/expected_outputs/find_population_structural_subsuming_variants/2.json
@@ -17,7 +17,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 }
             ]
@@ -38,7 +38,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_tx_implications/2.json
+++ b/tests/expected_outputs/find_population_tx_implications/2.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_tx_implications/3.json
+++ b/tests/expected_outputs/find_population_tx_implications/3.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_tx_implications/4.json
+++ b/tests/expected_outputs/find_population_tx_implications/4.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {

--- a/tests/expected_outputs/find_population_tx_implications/5.json
+++ b/tests/expected_outputs/find_population_tx_implications/5.json
@@ -13,7 +13,7 @@
                 {
                     "name": "denominator",
                     "valueQuantity": {
-                        "value": 1114
+                        "value": 1115
                     }
                 },
                 {


### PR DESCRIPTION
## Description

This pull request is to implement the change of the parameters resource wherein the resources produced no longer include parameter parts. Each variant/implication profile is now a separate resource housed within the parameters resource. 

Fixes # (issue)
This does not seem to be a fix but instead a refactoring or changing of logic. I could be wrong however. 

## How Has This Been Tested?
Please let me know if this is the correct way to test but I ran `OVERWRITE_TEST_EXPECTED_DATA=true python3 -m pytest  in the terminal and everything came back positive.  I would love to know how I can produce files on my local system to see if the correct resource is being produced (if possible). 
